### PR TITLE
Add Supabase connection URLs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# Connect to Supabase via connection pooling
+DATABASE_URL="postgresql://postgres.kximvddnirjpwlkgnnjx:[YOUR-PASSWORD]@aws-1-eu-west-2.pooler.supabase.com:6543/postgres?pgbouncer=true"
+
+# Direct connection to the database. Used for migrations
+DIRECT_URL="postgresql://postgres.kximvddnirjpwlkgnnjx:[YOUR-PASSWORD]@aws-1-eu-west-2.pooler.supabase.com:5432/postgres"
+
+# NextAuth configuration
+NEXTAUTH_SECRET="your_nextauth_secret"
+NEXTAUTH_URL="http://localhost:3000"
+
+# Google OAuth credentials
+GOOGLE_CLIENT_ID="your_google_client_id"
+GOOGLE_CLIENT_SECRET="your_google_client_secret"

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -10,7 +10,8 @@ generator client {
 
 datasource db {
   provider = "postgresql"
-  url      = env("DATABASE_URL")
+  url       = env("DATABASE_URL")
+  directUrl = env("DIRECT_URL")
 }
 
 model User {


### PR DESCRIPTION
## Summary
- allow committing `.env.example`
- add Supabase connection placeholders for pooler and direct connections
- reference `DIRECT_URL` in Prisma schema

## Testing
- `npm run test:run` *(fails: various unit tests and missing environment features)*

------
https://chatgpt.com/codex/tasks/task_e_68c7b750082c8329873209ba8423c87a