### PR TITLE
Use shared NextAuth configuration

### DIFF
--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,25 +1,6 @@
 import NextAuth from 'next-auth'
-import GoogleProvider from 'next-auth/providers/google'
+import { authOptions } from '@/lib/auth'
 
-const handler = NextAuth({
-  providers: [
-    GoogleProvider({
-      clientId: process.env.GOOGLE_CLIENT_ID!,
-      clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
-    }),
-  ],
-  callbacks: {
-    async session({ session, token }) {
-      return session
-    },
-    async jwt({ token, user }) {
-      return token
-    },
-  },
-  pages: {
-    signIn: '/auth/signin',
-    error: '/auth/error',
-  },
-})
+const handler = NextAuth(authOptions)
 
 export { handler as GET, handler as POST }


### PR DESCRIPTION
## Summary
- Connect NextAuth route to shared auth options

## Testing
- `npm test` *(fails: Theme Persistence Tests - Test timed out in 5000ms)*
- `npm run lint` *(fails: Unexpected any. Specify a different type)*

------
https://chatgpt.com/codex/tasks/task_e_68c7c9c2ed708329a2b71f45f388f85c