### PR TITLE
Handle missing database configuration in Prisma

### DIFF
--- a/src/app/api/auth/register/route.ts
+++ b/src/app/api/auth/register/route.ts
@@ -1,8 +1,18 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { prisma } from '@/lib/prisma'
+import { prisma, prismaConfigurationError } from '@/lib/prisma'
 import { hashPassword, validatePassword } from '@/lib/password'
 
 export async function POST(request: NextRequest) {
+  if (prismaConfigurationError) {
+    return NextResponse.json(
+      {
+        error: 'Service unavailable',
+        details: prismaConfigurationError,
+      },
+      { status: 503 }
+    )
+  }
+
   try {
     const { name, email, password } = await request.json()
 

--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
-import { prisma } from '@/lib/prisma';
+import { prisma, prismaConfigurationError } from '@/lib/prisma';
 import { UpdateTaskInput } from '@/lib/types';
 
 interface RouteParams {
@@ -12,6 +12,12 @@ interface RouteParams {
 
 export async function GET(request: NextRequest, context: RouteParams) {
   const params = await context.params;
+  if (prismaConfigurationError) {
+    return NextResponse.json(
+      { error: 'Service unavailable', details: prismaConfigurationError },
+      { status: 503 }
+    );
+  }
   try {
     const session = await getServerSession(authOptions);
     
@@ -69,6 +75,12 @@ export async function GET(request: NextRequest, context: RouteParams) {
 
 export async function PUT(request: NextRequest, context: RouteParams) {
   const params = await context.params;
+  if (prismaConfigurationError) {
+    return NextResponse.json(
+      { error: 'Service unavailable', details: prismaConfigurationError },
+      { status: 503 }
+    );
+  }
   try {
     const session = await getServerSession(authOptions);
     
@@ -195,6 +207,12 @@ export async function PUT(request: NextRequest, context: RouteParams) {
 
 export async function DELETE(request: NextRequest, context: RouteParams) {
   const params = await context.params;
+  if (prismaConfigurationError) {
+    return NextResponse.json(
+      { error: 'Service unavailable', details: prismaConfigurationError },
+      { status: 503 }
+    );
+  }
   try {
     const session = await getServerSession(authOptions);
     

--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -1,10 +1,17 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
-import { prisma } from '@/lib/prisma';
+import { prisma, prismaConfigurationError } from '@/lib/prisma';
 import { CreateTaskInput } from '@/lib/types';
 
 export async function GET(request: NextRequest) {
+  if (prismaConfigurationError) {
+    return NextResponse.json(
+      { error: 'Service unavailable', details: prismaConfigurationError },
+      { status: 503 }
+    );
+  }
+
   try {
     const session = await getServerSession(authOptions);
     
@@ -78,6 +85,13 @@ export async function GET(request: NextRequest) {
 }
 
 export async function POST(request: NextRequest) {
+  if (prismaConfigurationError) {
+    return NextResponse.json(
+      { error: 'Service unavailable', details: prismaConfigurationError },
+      { status: 503 }
+    );
+  }
+
   try {
     const session = await getServerSession(authOptions);
     

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -4,20 +4,55 @@ const globalForPrisma = globalThis as unknown as {
   prisma: PrismaClient | undefined
 }
 
-export const prisma =
-  globalForPrisma.prisma ??
+const datasourceUrl = process.env.DATABASE_URL ?? process.env.DIRECT_URL
+const missingDatasourceMessage =
+  'Database connection string is not configured. Please set DATABASE_URL or DIRECT_URL in your environment variables.'
+
+const createPrismaClient = () =>
   new PrismaClient({
     log: process.env.NODE_ENV === 'development' ? ['query'] : [],
     datasources: {
       db: {
-        url: process.env.DATABASE_URL,
+        url: datasourceUrl!,
       },
     },
   })
 
-if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma
+let prismaClient: PrismaClient
 
-// Graceful shutdown
-process.on('beforeExit', async () => {
-  await prisma.$disconnect()
-})
+if (datasourceUrl) {
+  prismaClient = globalForPrisma.prisma ?? createPrismaClient()
+
+  if (process.env.NODE_ENV !== 'production') {
+    globalForPrisma.prisma = prismaClient
+  }
+
+  // Graceful shutdown when Prisma is actually connected
+  process.on('beforeExit', async () => {
+    await prismaClient.$disconnect()
+  })
+} else {
+  if (process.env.NODE_ENV !== 'test') {
+    console.error(missingDatasourceMessage)
+  }
+
+  prismaClient = new Proxy(
+    {} as PrismaClient,
+    {
+      get(_target, prop) {
+        if (prop === '$disconnect') {
+          return async () => undefined
+        }
+
+        throw new Error(missingDatasourceMessage)
+      },
+    }
+  )
+
+  if (process.env.NODE_ENV !== 'production') {
+    globalForPrisma.prisma = prismaClient
+  }
+}
+
+export const prisma = prismaClient
+export const prismaConfigurationError = datasourceUrl ? null : missingDatasourceMessage


### PR DESCRIPTION
## Summary
- add a protective Prisma client wrapper that falls back to DIRECT_URL and surfaces a clear error when no database URL is configured
- short-circuit auth and task API routes with a 503 response when the database configuration is missing so the UI shows a helpful message instead of a 500

## Testing
- npm run test:run *(fails: suite has numerous existing failing tests unrelated to these changes)*

------
https://chatgpt.com/codex/tasks/task_e_68c84f6e5ba0832989454f549b4f731b